### PR TITLE
Use pcss extension by default, Fixes #1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
     markupExtension: String,
 
     // Extension for styles
-    #[structopt(short = "s", long = "styles-extension", default_value = ".css")]
+    #[structopt(short = "s", long = "styles-extension", default_value = ".pcss")]
     stylesExtension: String,
 
     // Extension for scripts


### PR DESCRIPTION
Our boilerplate defaults to pcss for postcss extensions, so use that by default